### PR TITLE
문제 제작 시 이미지 없음 이미지 url 처리 및 탈 아이콘 색 변경 관련 기능 추가

### DIFF
--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -42,7 +42,6 @@ export default function QuizPage() {
 
   useEffect(()=>{
     mounted.current = true;
-    setLoaded(0);
     async function InitProblems() {
       const heritageList : heritageListResponse[] = [];
       const initResPromises : Promise<heritageListResponse[]>[] = [];
@@ -72,7 +71,7 @@ export default function QuizPage() {
         const problemFactoryOutput : ProblemFactoryOutput | null = await GetProblem(input);
         if(!mounted.current) return;
         if(problemFactoryOutput){
-          if(problemFactoryOutput.url===''){
+          if(problemFactoryOutput.url==='' || problemFactoryOutput.url.includes('no_image')){
             listInd++;
             continue;
           }
@@ -93,7 +92,7 @@ export default function QuizPage() {
     return ()=>{
       mounted.current = false;
     }
-  }, [totalNumItems]);
+  }, []);
 
   //TODO : Custom Hook
   const refs = useRef(problems.current.map(()=>createRef<HTMLDivElement>()));

--- a/src/app/quizRanking/components/RankingCard.tsx
+++ b/src/app/quizRanking/components/RankingCard.tsx
@@ -8,6 +8,7 @@ import Table from '@/components/quiz/Table';
 import useQuizInfoManager, { quizInfo } from '@/components/quiz/useQuizInfoManager';
 import GagsiMaskIcon from '@/components/quiz/svg/GagsiMaskIcon';
 import Link from 'next/link';
+import GetUserRankColor from '@/components/quiz/quizRankData';
 
 type DataType = {
   standings: number;
@@ -32,7 +33,7 @@ export default function RankingCard() {
   }
   useEffect(()=>{
     const temp = getAllQuizInfo();
-    temp.then((data : quizInfo[])=>{
+    temp.then(async (data : quizInfo[])=>{
       const ImpRankings : ImpRankData[] = [];
       // Weekly
       const weeklyData : [string, number, number, number][] = data.map<[string, number, number, number]>((elem)=>[
@@ -42,9 +43,9 @@ export default function RankingCard() {
         elem.scores.length
       ]);
       weeklyData.sort((a, b)=>b[2]-a[2]);
-      ImpRankings.push({userId : weeklyData[0][0], color: '#000000'});
+      ImpRankings.push({userId : weeklyData[0][0], color: (await GetUserRankColor(weeklyData[0][0]))[0] });
       weeklyData.sort((a, b)=>b[3]-a[3]);
-      ImpRankings.push({userId : weeklyData[0][0], color: '#000000'});
+      ImpRankings.push({userId : weeklyData[0][0], color: (await GetUserRankColor(weeklyData[0][0]))[0] });
       //Daily
       const dailyData : [string, number, number, number][] = data.map<[string, number, number, number]>((elem)=>[
         elem.id, 
@@ -53,23 +54,26 @@ export default function RankingCard() {
         elem.scores.length
       ]);
       dailyData.sort((a, b)=>b[2]-a[2]);
-      ImpRankings.push({userId : dailyData[0][0], color: '#000000'});
+      ImpRankings.push({userId : dailyData[0][0], color: (await GetUserRankColor(weeklyData[0][0]))[0] });
       dailyData.sort((a, b)=>b[3]-a[3]);
-      ImpRankings.push({userId : dailyData[0][0], color: '#000000'});
+      ImpRankings.push({userId : dailyData[0][0], color: (await GetUserRankColor(weeklyData[0][0]))[0] });
       setImpRankings(ImpRankings);
 
       data.sort((a, b)=>b.highScore-a.highScore);
-      setAllQuizInfo(data.map<DataType>((elem, index)=>{
+      const allConvData : DataType[] = [];
+      for(let i = 0; i < data.length; i++){
+        const elem = data[i];
         const convData : DataType = {
-          standings: index + 1,
-          rank: gagsiTalWithColor('#000000'),
+          standings: i + 1,
+          rank: gagsiTalWithColor((await GetUserRankColor(elem.id))[0]),
           id: userDetailsLink(elem.id, elem.name),
           highScore: elem.highScore,
           attempts: elem.scores.length,
           date: elem.scores.slice(-1)[0][1].toLocaleString(),
         }
-        return convData;
-      }));
+        allConvData.push(convData);
+      }
+      setAllQuizInfo(allConvData);
     });
   }, [getAllQuizInfo]);
 

--- a/src/app/quizRanking/components/StatisticsCard.tsx
+++ b/src/app/quizRanking/components/StatisticsCard.tsx
@@ -12,6 +12,7 @@ import { ChartJSOrUndefined } from 'react-chartjs-2/dist/types';
 import { useAppSelector } from '@/lib/redux/store';
 import axios from 'axios';
 import useQuizInfoManager, {quizInfo} from '@/components/quiz/useQuizInfoManager';
+import GetUserRankColor from '@/components/quiz/quizRankData';
 
 export default function StatisticsCard() {
   const {isAuth, userId} = useAppSelector((state) => state.authReducer.value);
@@ -277,6 +278,12 @@ export default function StatisticsCard() {
     Init();
   }, [getAllQuizInfo, userId, testFunc]);
 
+  const [iconColor, setIconColor] = useState<[string, string]>(['','']);
+  useEffect(()=>{
+    async function RankColor(){ setIconColor(await GetUserRankColor(userId)); };
+    RankColor();
+  }, [userId]);
+
   return (
     <div className='w-full min-w-[800px] max-w-[1000px] h-auto flex flex-col items-center backdrop-blur-xl rounded-lg shadow-2xl overflow-hidden pb-10'>
       {/* Card Header */}
@@ -309,7 +316,8 @@ export default function StatisticsCard() {
             </div>
             {/* 각시탈 아이콘 */}
             {/* TODO: 랭크에 맞게 색 설정하기 */}
-            <GagsiMaskIcon color='#000000' className=' w-[50%] aspect-square rounded-full border-[3px] border-black overflow-hidden self-end justify-self-end -rotate-[25deg] opacity-75' />
+            {!isAuth && <GagsiMaskIcon color='#000000' className=' w-[50%] aspect-square rounded-full border-[3px] border-black overflow-hidden self-end justify-self-end -rotate-[25deg] opacity-75' />}
+            {isAuth && <GagsiMaskIcon color={iconColor[0]} className={' w-[50%] aspect-square rounded-full border-[3px] overflow-hidden self-end justify-self-end -rotate-[25deg] opacity-75 ' + iconColor[1]} />}
           </div>
         </div>
       </div>

--- a/src/app/quizResults/components/QuizResultsCard.tsx
+++ b/src/app/quizResults/components/QuizResultsCard.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import Table from '../../../components/quiz/Table'
 import GagsiMaskIcon from '../../../components/quiz/svg/GagsiMaskIcon';
 import { useAppSelector } from '@/lib/redux/store';
+import GetUserRankColor from '@/components/quiz/quizRankData';
 
 export type DataType = {
   id: string,
@@ -19,7 +20,13 @@ interface QuizResultsCardProps {
 }
 
 export default function QuizResultsCard(props : QuizResultsCardProps) {
-  const { userName } = useAppSelector((state) => state.authReducer.value);
+  const { userId, userName } = useAppSelector((state) => state.authReducer.value);
+
+  const [iconColor, setIconColor] = useState<[string, string]>(['','']);
+  useEffect(()=>{
+    async function RankColor(){ setIconColor(await GetUserRankColor(userId)); };
+    RankColor();
+  }, [userId]);
 
   return (
     <div className='pb-5'>
@@ -29,7 +36,7 @@ export default function QuizResultsCard(props : QuizResultsCardProps) {
         <div className='w-full h-8 border-b flex items-center'>
           <span className='text-black text-sm font-bold'>{ userName } : {props.score}점</span>
         </div>
-        <GagsiMaskIcon color={"#FF4444"} className='w-[25%] aspect-square self-end mt-[-25px] -rotate-[25deg] rounded-full overflow-hidden border-[3px] border-[#FF4444]'/>
+        <GagsiMaskIcon color={iconColor[0]} className={'w-[25%] aspect-square self-end mt-[-25px] -rotate-[25deg] rounded-full overflow-hidden border-[3px] ' + iconColor[1]}/>
       </div>
     </div>
   )

--- a/src/app/rankingDetail/page.tsx
+++ b/src/app/rankingDetail/page.tsx
@@ -18,6 +18,7 @@ import 'swiper/css';
 import useQuizInfoManager from '@/components/quiz/useQuizInfoManager';
 import { redirect, useSearchParams } from 'next/navigation';
 import axios from 'axios';
+import GetUserRankColor from '@/components/quiz/quizRankData';
 
 export default function RankingDetail() {
   const searchParams = useSearchParams();
@@ -97,8 +98,12 @@ export default function RankingDetail() {
   };
   const [commentsData, setCommentsData] = useState<CommentDataType[]>([]);
 
+  const [iconColor, setIconColor] = useState<[string, string]>(['','']);
+
   useEffect(()=>{
     async function Init(){
+      if(uid) setIconColor(await GetUserRankColor(uid));
+
       const userObj = await axios.get(`${process.env.NEXT_PUBLIC_BASIC_URL}/users/${uid}`);
       if(userObj.status !== 200) redirect('/quizRanking');
       labels.current[0] = userObj.data.email ?? '';
@@ -239,7 +244,7 @@ export default function RankingDetail() {
       <div className='w-full min-w-[900px] max-w-[1200px] flex flex-col justify-center items-center mb-4'>
         {/* Social info */}
         <div className='w-[80%] place-content-evenly flex items-end overflow-hidden lg:mt-[-100px] mt-4 mb-4'>
-          <GagsiMaskIcon color={'#000000'} className='w-[25%] aspect-square rounded-full overflow-hidden flex flex-col items-center justify-center bg-white border-4 border-black'/>
+          <GagsiMaskIcon color={iconColor[0]} className={'w-[25%] aspect-square rounded-full overflow-hidden flex flex-col items-center justify-center bg-white border-4 ' + iconColor[1]}/>
           {labels.current.map((elem, index)=>socialData(elem, value.current[index], index))}
         </div>
         {/* 문화재 퀴즈 최근 결과 */}

--- a/src/components/quiz/quizRankData.ts
+++ b/src/components/quiz/quizRankData.ts
@@ -1,0 +1,50 @@
+import axios from "axios";
+
+export type quizInfo = {
+  id: string;
+  name: string;
+  highScore : number;
+}
+
+const Breakpoints = {
+  10 : ['#FF2222', 'border-[#FF2222]'],
+  20 : ['#22FF22', 'border-[#22FF22]'],
+  30 : ['#2222FF', 'border-[#2222FF]'],
+  40 : ['#FFFF22', 'border-[#FFFF22]'],
+  50 : ['#FF22FF', 'border-[#FF22FF]'],
+  100 :['#222222', 'border-[#222222]']
+}
+
+export default async function GetUserRankColor(userId : string) : Promise<[string, string]> {
+  const quizChannelId = (await axios.get(`${process.env.NEXT_PUBLIC_BASIC_URL}/channels/quiz`)).data._id;
+  const quizChannelPosts = (await axios.get(`${process.env.NEXT_PUBLIC_BASIC_URL}/posts/channel/${quizChannelId}`)).data;
+  const allUserData : quizInfo[] = []
+  quizChannelPosts.map((post)=>{
+    const data : {
+      id: string;
+      highScore : string;
+      scores : [string, string][];
+      errRate_Correct : [string, string][];
+      errRate_Total : [string, string][];
+      name : string;
+    } = JSON.parse(post.title);
+    const intData : quizInfo = {
+      id : data.id,
+      name: data.name,
+      highScore: parseInt(data.highScore),
+    };
+    allUserData.push(intData);
+  });
+  allUserData.sort((a, b)=>b.highScore - a.highScore);
+  const uInd = allUserData.findIndex((elem)=>elem.id===userId);
+  const position = (uInd + 1) / allUserData.length;
+  for(let i = 0; i < Object.entries(Breakpoints).length; i++){
+    if(position * 100 <= parseInt(Object.entries(Breakpoints)[i][0])){
+      return [
+        Object.entries(Breakpoints)[i][1][0], 
+        Object.entries(Breakpoints)[i][1][1]
+      ];
+    }
+  }
+  return ['#222222', 'border-[#FFFFFF00]'];
+}


### PR DESCRIPTION
1. @/components/quiz/quizRankData.ts 임포트
2. GetUserRankColor(__userId__) 가 [색 헥사 값, border-[색 헥사 값]] : [string, string] 형태의 스트링 튜플을 반환
3. tailwind 가 온전한 스트링만 사용할 수 있어서 보더 tailwind 값을 추가로 반환
4. 사용방법

초기화 부분
const [iconColor, setIconColor] = useState<[string, string]>(['','']);
useEffect(()=>{
    async function RankColor(){ setIconColor(await GetUserRankColor(userId)); };
    RankColor();
}, [userId]);

JSX에서 :
  <GagsiMaskIcon color={iconColor[0]} className={'w-[25%] aspect-square self-end mt-[-25px] -rotate-[25deg] rounded-full overflow-hidden border-[3px] ' + iconColor[1]}/>